### PR TITLE
Update cleaning up expired sessions

### DIFF
--- a/lib/connect-dynamodb.js
+++ b/lib/connect-dynamodb.js
@@ -191,9 +191,14 @@ module.exports = function (connect) {
             },
             AttributesToGet: ["id"]
         };
-        this.client.scan(params, function (err, data) {
+        this.client.scan(params, function onScan(err, data) {
             if (err) return fn && fn(err);
             destroy.call(this, data, fn);
+            if (typeof data.LastEvaluatedKey != "undefined") {
+                //console.log("Scanning for more...");
+                params.ExclusiveStartKey = data.LastEvaluatedKey;
+                this.client.scan(params, onScan);
+            }            
         }.bind(this));
     };
 


### PR DESCRIPTION
Because a single call to DynamoDB Scan will not return all the items
